### PR TITLE
Fix --skipUpdateMasterlist argument being ignored

### DIFF
--- a/src/lootthread.cpp
+++ b/src/lootthread.cpp
@@ -734,12 +734,17 @@ int LOOTWorker::run()
       std::locale::global(gen(m_Language + ".UTF-8"));
     }
 
-    if (true) {
-      progress(Progress::CheckingMasterlistExistence);
-      if (!fs::exists(masterlistPath())) {
-        fs::create_directories(masterlistPath().parent_path());
+    progress(Progress::CheckingMasterlistExistence);
+    if (!fs::exists(masterlistPath())) {
+      if (!m_UpdateMasterlist) {
+        log(loot::LogLevel::error,
+            "Masterlist not found at: " + masterlistPath().string());
+        return FALSE;
       }
+      fs::create_directories(masterlistPath().parent_path());
+    }
 
+    if (m_UpdateMasterlist) {
       progress(Progress::UpdatingMasterlist);
       std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
       std::wstring masterlistSource =


### PR DESCRIPTION
This PR fixes the `--skipUpdateMasterlist` argument being ignored. If this argument is passed while there is no existing masterlist file, an error is logged.

Fixes ModOrganizer2/modorganizer#1955.