### PR TITLE
Update game masterlist repository names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  VCPKG_BINARY_SOURCES: clear;x-azblob,${{ vars.AZ_BLOB_VCPKG_URL }},${{ secrets.AZ_BLOB_SAS }},readwrite
+  VCPKG_BINARY_SOURCES: ${{ vars.AZ_BLOB_VCPKG_URL != '' && format('clear;x-azblob,{0},{1},readwrite', vars.AZ_BLOB_VCPKG_URL, secrets.AZ_BLOB_SAS) || '' }}
 
 jobs:
   build:

--- a/src/game_settings.cpp
+++ b/src/game_settings.cpp
@@ -265,7 +265,6 @@ std::string GetDefaultMasterlistRepositoryName(const GameId gameId)
     return "morrowind";
   case GameId::tes4:
   case GameId::nehrim:
-  case GameId::oblivionRemastered:
     return "oblivion";
   case GameId::tes5:
     return "skyrim";
@@ -286,6 +285,8 @@ std::string GetDefaultMasterlistRepositoryName(const GameId gameId)
     return "fallout4vr";
   case GameId::starfield:
     return "starfield";
+  case GameId::oblivionRemastered:
+    return "oblivion-remastered";
   default:
     throw std::logic_error("Unrecognised game type");
   }

--- a/src/lootthread.cpp
+++ b/src/lootthread.cpp
@@ -513,8 +513,9 @@ LOOTWorker::migrateMasterlistRepoSettings(loot::GameId GameId, std::string url,
 std::string LOOTWorker::migrateMasterlistSource(const std::string& source)
 {
   static const std::vector<std::string> officialMasterlistRepos = {
-      "morrowind", "oblivion",  "skyrim",   "skyrimse",   "skyrimvr",
-      "fallout3",  "falloutnv", "fallout4", "fallout4vr", "enderal"};
+      "morrowind",  "oblivion", "skyrim",    "skyrimse",
+      "skyrimvr",   "fallout3", "falloutnv", "fallout4",
+      "fallout4vr", "enderal",  "starfield", "oblivion-remastered"};
 
   for (const auto& repo : officialMasterlistRepos) {
     for (const auto& branch : oldDefaultBranches) {

--- a/src/version.rc
+++ b/src/version.rc
@@ -22,7 +22,7 @@ VALUE "CompanyName", "Mod Organizer 2 Team\0"
 VALUE "FileDescription",  "LOOT Command line interface\0"
 VALUE "OriginalFilename", "lootcli.exe\0"
 VALUE "InternalName", "lootcli\0"
-VALUE "LegalCopyright", "Copyright 2011-2016 Sebastian Herbord\r\nCopyright 2016-2025 Mod Organizer 2 contributors\0"
+VALUE "LegalCopyright", "Copyright 2011-2016 Sebastian Herbord\r\nCopyright 2016-2026 Mod Organizer 2 contributors\0"
 VALUE "ProductName",      "lootcli\0"
 VALUE "ProductVersion", VER_FILEVERSION_STR
 END


### PR DESCRIPTION
LOOT has a [separate repository](https://github.com/loot/oblivion-remastered) for Oblivion Remastered, but the default repository was set to the one for the original Oblivion. This PR fixes that. I also added Starfield and Oblivion Remastered to the `officialMasterlistRepos` in the `LOOTWorker::migrateMasterlistSource` method, so old masterlists of those games will also be migrated to the latest version.