### PR TITLE
Upgrade to libloot 0.29.5

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,7 +22,7 @@
       {
         "kind": "git",
         "repository": "https://github.com/ModOrganizer2/vcpkg-registry",
-        "baseline": "f28e6416f0927869cfd995e1265481e73a3b4dd7",
+        "baseline": "55a2a94b84e6103e4b0fe069a0aa07e512e0570e",
         "packages": ["libloot"]
       }
     ]


### PR DESCRIPTION
Requires https://github.com/ModOrganizer2/vcpkg-registry/pull/7